### PR TITLE
Move forcePullImage deeper into JSON

### DIFF
--- a/marathon_app.go
+++ b/marathon_app.go
@@ -39,18 +39,18 @@ type MarathonApp struct {
 }
 
 type MarathonAppContainer struct {
-	ContainerType  string                       `yaml:"type" json:"type,omitempty"`
-	Docker         *MarathonAppContainerDocker  `yaml:"docker" json:"docker,omitempty"`
-	ForcePullImage bool                         `yaml:"forcePullImage" json:"forcePullImage,omitempty"`
-	Volumes        []MarathonAppContainerVolume `yaml:"volumes" json:"volumes,omitempty"`
+	ContainerType string                       `yaml:"type" json:"type,omitempty"`
+	Docker        *MarathonAppContainerDocker  `yaml:"docker" json:"docker,omitempty"`
+	Volumes       []MarathonAppContainerVolume `yaml:"volumes" json:"volumes,omitempty"`
 }
 
 type MarathonAppContainerDocker struct {
-	Image        string                                   `yaml:"image" json:"image,omitempty"`
-	Network      string                                   `yaml:"network" json:"network,omitempty"`
-	PortMappings []MarathonAppContainerDockerPortMappings `yaml:"portMappings" json:"portMappings,omitempty"`
-	Privileged   *bool                                    `yaml:"privileged" json:"privileged,omitempty"`
-	Parameters   []MarathonAppContainerDockerParameters   `yaml:"parameters" json:"parameters,omitempty"`
+	Image          string                                   `yaml:"image" json:"image,omitempty"`
+	Network        string                                   `yaml:"network" json:"network,omitempty"`
+	PortMappings   []MarathonAppContainerDockerPortMappings `yaml:"portMappings" json:"portMappings,omitempty"`
+	Privileged     *bool                                    `yaml:"privileged" json:"privileged,omitempty"`
+	Parameters     []MarathonAppContainerDockerParameters   `yaml:"parameters" json:"parameters,omitempty"`
+	ForcePullImage bool                                     `yaml:"forcePullImage" json:"forcePullImage,omitempty"`
 }
 
 type MarathonAppContainerDockerPortMappings struct {

--- a/marathon_app_test.go
+++ b/marathon_app_test.go
@@ -22,8 +22,8 @@ const (
 	MarathonAppFetchTrueTestJSON                   = `{"uri":"http://b3ta.com","extract":true,"executable":true,"cache":true}`
 	MarathonAppContainerVolumeTestJSON             = `{"containerPath":"container-path","hostPath":"host-path","mode":"mode"}`
 	MarathonAppContainerDockerPortMappingsTestJSON = `{"containerPort":8080,"hostPort":31001,"protocol":"HTTP","servicePort":15001}`
-	MarathonAppContainerDockerTestJSON             = `{"image":"registry.nutmeg.co.uk:8443/...","network":"BRIDGE","portMappings":[{"containerPort":8080,"hostPort":31001,"protocol":"HTTP","servicePort":15001},{}],"privileged":false,"parameters":[{"key":"key1","value":"value1"},{"key":"key2","value":"value2"}]}`
-	MarathonAppContainerTestJSON                   = `{"type":"DOCKER","forcePullImage":true}`
+	MarathonAppContainerDockerTestJSON             = `{"image":"registry.nutmeg.co.uk:8443/...","network":"BRIDGE","portMappings":[{"containerPort":8080,"hostPort":31001,"protocol":"HTTP","servicePort":15001},{}],"privileged":false,"parameters":[{"key":"key1","value":"value1"},{"key":"key2","value":"value2"}],"forcePullImage":true}`
+	MarathonAppContainerTestJSON                   = `{"type":"DOCKER"}`
 )
 
 func TestMinimumOutput(t *testing.T) {
@@ -256,6 +256,7 @@ func TestMarathonAppContainerDockerFull(t *testing.T) {
 	m := MarathonAppContainerDocker{}
 	m.Image = "registry.nutmeg.co.uk:8443/..."
 	m.Network = "BRIDGE"
+	m.ForcePullImage = true
 	macdp := make([]MarathonAppContainerDockerParameters, 2)
 	macdp[0].Key = "key1"
 	macdp[0].Value = "value1"
@@ -316,7 +317,6 @@ func TestMarathonAppContainerEmpty(t *testing.T) {
 func TestMarathonAppContainerFull(t *testing.T) {
 	m := MarathonAppContainer{}
 	m.ContainerType = "DOCKER"
-	m.ForcePullImage = true
 
 	b, err := json.Marshal(m)
 	if err != nil {


### PR DESCRIPTION
[Marathon HTTP API docs](https://mesosphere.github.io/marathon/docs/native-docker.html#forcing-a-docker-pull) suggest that `forcePullImage` goes in the `docker: {}` block instead of the `container: {}` level. 

Updated structure and tests to reflect this