### PR TITLE
Add Name field for portMappings

### DIFF
--- a/marathon_app.go
+++ b/marathon_app.go
@@ -58,6 +58,7 @@ type MarathonAppContainerDockerPortMappings struct {
 	HostPort      *int   `yaml:"hostPort" json:"hostPort,omitempty"`
 	Protocol      string `yaml:"protocol" json:"protocol,omitempty"`
 	ServicePort   int    `yaml:"servicePort" json:"servicePort,omitempty"`
+	Name          string `yaml:"name" json:"name,omitempty"`
 }
 
 type MarathonAppContainerDockerParameters struct {

--- a/marathon_app_test.go
+++ b/marathon_app_test.go
@@ -21,7 +21,7 @@ const (
 	MarathonAppFetchFalseTestJSON                  = `{"uri":"http://b3ta.com","extract":false,"executable":false,"cache":false}`
 	MarathonAppFetchTrueTestJSON                   = `{"uri":"http://b3ta.com","extract":true,"executable":true,"cache":true}`
 	MarathonAppContainerVolumeTestJSON             = `{"containerPath":"container-path","hostPath":"host-path","mode":"mode"}`
-	MarathonAppContainerDockerPortMappingsTestJSON = `{"containerPort":8080,"hostPort":31001,"protocol":"HTTP","servicePort":15001}`
+	MarathonAppContainerDockerPortMappingsTestJSON = `{"containerPort":8080,"hostPort":31001,"protocol":"HTTP","servicePort":15001,"name":"http"}`
 	MarathonAppContainerDockerTestJSON             = `{"image":"registry.nutmeg.co.uk:8443/...","network":"BRIDGE","portMappings":[{"containerPort":8080,"hostPort":31001,"protocol":"HTTP","servicePort":15001},{}],"privileged":false,"parameters":[{"key":"key1","value":"value1"},{"key":"key2","value":"value2"}],"forcePullImage":true}`
 	MarathonAppContainerTestJSON                   = `{"type":"DOCKER"}`
 )
@@ -234,6 +234,7 @@ func TestMarathonAppContainerDockerPortMappingsFull(t *testing.T) {
 	m.HostPort = &hostPort
 	m.Protocol = "HTTP"
 	m.ServicePort = 15001
+	m.Name = "http"
 
 	b, err := json.Marshal(m)
 	if err != nil {


### PR DESCRIPTION
+ Add `name` field to application port mappings for Marathon. Will allow ports to be named via marathon-config-generator and submitted to Marathon as JSON. This can help identify ports when services have multiple ports.

```json
"portMappings": [
  {
    "containerPort": 80,
    "hostPort": 0,
    "protocol": "tcp",
    "servicePort": 10019,
    "name": "http",
    "labels": {
      "vip": "192.168.0.1:80"
    }
  }
]
```